### PR TITLE
Filter out pages from graph

### DIFF
--- a/src/contexts/graph/hooks/useFetchERC1155.tsx
+++ b/src/contexts/graph/hooks/useFetchERC1155.tsx
@@ -48,7 +48,17 @@ export const useFetchERC1155 = (): { ERC1155: Nft[]; isLoading: boolean } => {
             tokenURI: nft.tokenURI,
           });
         });
-      if (usersNfts1155.length > 0) {
+      const items: Nft[] = [];
+      const resultIds = new Set();
+      usersNfts1155.forEach((nft) => {
+        const id = getUniqueID(nft.address, nft.tokenId);
+        if (!resultIds.has(id)) {
+          items.push(nft);
+          resultIds.add(id);
+        }
+      });
+
+      if (items.length > 0) {
         setNfts([...usersNfts1155, ...nfts]);
       }
       setLoading(false);

--- a/src/contexts/graph/hooks/useFetchERC721.tsx
+++ b/src/contexts/graph/hooks/useFetchERC721.tsx
@@ -47,9 +47,18 @@ export const useFetchERC721 = (): { ERC721: Nft[]; isLoading: boolean } => {
             tokenURI: nft.tokenURI,
           });
         });
+      const items: Nft[] = [];
+      const resultIds = new Set();
+      usersNfts721.forEach((nft) => {
+        const id = getUniqueID(nft.address, nft.tokenId);
+        if (!resultIds.has(id)) {
+          items.push(nft);
+          resultIds.add(id);
+        }
+      });
 
-      if (usersNfts721.length > 0) {
-        setNfts([...usersNfts721, ...nfts]);
+      if (items.length > 0) {
+        setNfts([...items, ...nfts]);
       }
       setLoading(false);
     }


### PR DESCRIPTION
Multiple items showing up in the pages due to different graph pages return the same item, as the previous page.